### PR TITLE
args value are not printed as default

### DIFF
--- a/src/MainApp.cs
+++ b/src/MainApp.cs
@@ -6,7 +6,7 @@ public class MainApp
     {
         for (int i = 0; i < args.Length; i++)
         {
-           string output = String.Format("argv[{0}]: {0}", i, args[i]);
+           string output = String.Format("argv[{0}]: {1}", i, args[i]);
            Console.WriteLine(output);
         }
     }


### PR DESCRIPTION
Default output is like this.

```
> mono TheApp.exe hoge fuga
argv[0]: 0
argv[1]: 1
```

Probably expected is 

```
> mono TheApp.exe hoge fuga
argv[0]: hoge
argv[1]: fuga
```


@TsubasK111 review me